### PR TITLE
Feature/auto cleanup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
             }
         ],
         "@typescript-eslint/no-empty-function": "error",
+        "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-empty-interface": "error",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-this-alias": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to aws organization formation will be documented in this file.
 
+
+**not yet released**
+- Added flag --perform-cleanup to perform-tasks to automatically delete stacks removed from tasks file
+
 **version 0.9.2**
 - Fixed issue with init-pipeline failing due to wrong option on codebuild script
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -173,6 +173,8 @@ Will perform tasks from *tasksFile*.
 
 |option|default|description|
 |---|---|---|
+|<nobr>--logical-name</nobr>| 'default' | logical name of the tasks file, allows multiple tasks files to be used together with --perform-cleanup action |
+|<nobr>--perform-cleanup</nobr>| false | when set will cleanup resources created by previous perform-tasks after task is removed from tasks file |
 |<nobr>--max-concurrent-tasks</nobr> | 1 | Maximum number of tasks to be executed concurrently|
 |<nobr>--failed-tasks-tolerance</nobr> | 0 | The number of failed tasks after which execution stops|
 |<nobr>--max-concurrent-stacks</nobr> | 1 | Maximum number of stacks (within a task) to be executed concurrently |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7535,7 +7535,7 @@
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
             "dev": true
         },
         "tsutils": {

--- a/src/build-tasks/build-task-provider.ts
+++ b/src/build-tasks/build-task-provider.ts
@@ -4,6 +4,7 @@ import { OrgFormationError } from '../org-formation-error';
 import { BuildConfiguration, BuildTaskType, IBuildTask, IBuildTaskConfiguration, IIncludeTaskConfiguration, IUpdateOrganizationTaskConfiguration, IUpdateStackTaskConfiguration } from './build-configuration';
 import { BuildRunner } from './build-runner';
 import { Validator } from '~parser/validator';
+import { ITrackedTask } from '~state/persisted-state';
 import {
     ICommandArgs,
     IUpdateOrganizationCommandArgs,
@@ -11,6 +12,8 @@ import {
     UpdateOrganizationCommand,
     UpdateStacksCommand,
     ValidateStacksCommand,
+    IPerformTasksCommandArgs,
+    DeleteStacksCommand,
 } from '~commands/index';
 
 
@@ -46,6 +49,41 @@ export class BuildTaskProvider {
             default:
                 throw new OrgFormationError(`unable to load file ${configuration.FilePath}, unknown configuration type ${configuration.Type}`);
         }
+    }
+
+    public static createDeleteTask(logicalId: string, type: string, physicalId: string, command: ICommandArgs): IBuildTask | undefined {
+        switch (type) {
+            case 'update-stacks':
+                return new DeleteStacksTask(logicalId, physicalId, command);
+        }
+
+        return undefined;
+    }
+
+    public static enumTasksForCleanup(previouslyTracked: ITrackedTask[], tasks: IBuildTask[], command: ICommandArgs): IBuildTask[] {
+        const result: IBuildTask[] = [];
+        const currentTasks = BuildTaskProvider.recursivelyFilter(tasks, t => t.physicalIdForCleanup !== undefined);
+        const physicalIds = currentTasks.map(x=>x.physicalIdForCleanup);
+        for(const tracked of previouslyTracked) {
+            if (!physicalIds.includes(tracked.physicalIdForCleanup)) {
+                const deleteTask = this.createDeleteTask(tracked.logicalName, tracked.type, tracked.physicalIdForCleanup, command);
+                if (deleteTask !== undefined) {
+                    result.push(deleteTask);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static recursivelyFilter(tasks: IBuildTask[], filter: (task: IBuildTask) => boolean): IBuildTask[] {
+        const result = tasks.filter(filter);
+        const tasksWithChildren = tasks.filter(x => x.childTasks && x.childTasks.length > 0);
+        const childrenFlattened = tasksWithChildren.reduce((acc: IBuildTask[], x: IBuildTask)=> acc.concat(...x.childTasks), []);
+        if (childrenFlattened.length > 0) {
+            const resultFromChildren = BuildTaskProvider.recursivelyFilter(childrenFlattened, filter);
+            return result.concat(resultFromChildren);
+        }
+        return result;
     }
 }
 
@@ -119,6 +157,45 @@ class ValidateIncludeTask extends BaseIncludeTask {
     }
 }
 
+export class DeleteStacksTask implements IBuildTask {
+    name: string;
+    stackName: string;
+    command: ICommandArgs;
+    type: BuildTaskType = 'delete-stacks';
+    childTasks: IBuildTask[] = [];
+    physicalIdForCleanup?: string = undefined;
+    performCleanup = false;
+
+    constructor(logicalName: string, stackName: string, command: ICommandArgs) {
+        this.name = logicalName;
+        this.stackName = stackName;
+        this.command = command;
+        this.performCleanup = (command as IPerformTasksCommandArgs).performCleanup;
+    }
+
+    isDependency(): boolean {
+        return false;
+    }
+
+    async perform(): Promise<void> {
+        if (!this.performCleanup) {
+            ConsoleUtil.LogWarning('Hi there, it seems you have removed a task!');
+            ConsoleUtil.LogWarning(`The task was called ${this.name}  and used to deploy stacks by name of ${this.stackName}.`);
+            ConsoleUtil.LogWarning('By default these stacks dont get cleaned up. You can change this by adding the option --perfom-cleanup.');
+            ConsoleUtil.LogWarning('You can remove the stacks manually by running the following command:');
+            ConsoleUtil.LogWarning('');
+            ConsoleUtil.LogWarning(`    org-formation delete-stacks --stack-name ${this.stackName}`);
+            ConsoleUtil.LogWarning('');
+            ConsoleUtil.LogWarning('Did you not remove a task? but are you logically using different files? check out the --task-file-name option.');
+        } else {
+            ConsoleUtil.LogInfo(`executing: ${this.type} ${this.stackName}`);
+            await DeleteStacksCommand.Perform({...this.command, stackName: this.stackName, maxConcurrentStacks: 1, failedStacksTolerance: 0});
+        }
+    }
+
+
+}
+
 export abstract class BaseStacksTask implements IBuildTask {
     public name: string;
     public type: BuildTaskType;
@@ -126,6 +203,7 @@ export abstract class BaseStacksTask implements IBuildTask {
     public stackName: string;
     public templatePath: string;
     public childTasks: IBuildTask[] = [];
+    public physicalIdForCleanup?: string = undefined;
     protected config: IUpdateStackTaskConfiguration;
     private command: any;
     private dir: string;
@@ -216,6 +294,11 @@ export abstract class BaseStacksTask implements IBuildTask {
 
 export class UpdateStacksTask extends BaseStacksTask {
 
+    constructor(config: IUpdateStackTaskConfiguration, command: ICommandArgs) {
+        super(config, command);
+        this.physicalIdForCleanup = config.StackName;
+    }
+
     public async innerPerform(args: IUpdateStacksCommandArgs): Promise<void> {
         ConsoleUtil.LogInfo(`executing: ${this.config.Type} ${this.templatePath} ${this.stackName}`);
         await UpdateStacksCommand.Perform(args);
@@ -245,8 +328,8 @@ export abstract class BaseOrganizationTask implements IBuildTask {
         const dir = path.dirname(config.FilePath);
         this.templatePath = path.join(dir, config.Template);
         this.command = command;
-
     }
+
     public async perform(): Promise<void> {
 
         const updateCommand = this.command as IUpdateOrganizationCommandArgs;

--- a/src/build-tasks/build-task-provider.ts
+++ b/src/build-tasks/build-task-provider.ts
@@ -180,13 +180,13 @@ export class DeleteStacksTask implements IBuildTask {
     async perform(): Promise<void> {
         if (!this.performCleanup) {
             ConsoleUtil.LogWarning('Hi there, it seems you have removed a task!');
-            ConsoleUtil.LogWarning(`The task was called ${this.name}  and used to deploy stacks by name of ${this.stackName}.`);
+            ConsoleUtil.LogWarning(`The task was called ${this.name} and used to deploy stacks by name of ${this.stackName}.`);
             ConsoleUtil.LogWarning('By default these stacks dont get cleaned up. You can change this by adding the option --perfom-cleanup.');
             ConsoleUtil.LogWarning('You can remove the stacks manually by running the following command:');
             ConsoleUtil.LogWarning('');
             ConsoleUtil.LogWarning(`    org-formation delete-stacks --stack-name ${this.stackName}`);
             ConsoleUtil.LogWarning('');
-            ConsoleUtil.LogWarning('Did you not remove a task? but are you logically using different files? check out the --task-file-name option.');
+            ConsoleUtil.LogWarning('Did you not remove a task? but are you logically using different files? check out the --logical-name option.');
         } else {
             ConsoleUtil.LogInfo(`executing: ${this.type} ${this.stackName}`);
             await DeleteStacksCommand.Perform({...this.command, stackName: this.stackName, maxConcurrentStacks: 1, failedStacksTolerance: 0});

--- a/src/commands/delete-stacks.ts
+++ b/src/commands/delete-stacks.ts
@@ -11,7 +11,13 @@ const commandDescription = 'removes all stacks deployed to accounts using org-fo
 
 export class DeleteStacksCommand extends BaseCliCommand<IDeleteStackCommandArgs> {
 
-    constructor(command: Command) {
+
+    public static async Perform(command: IDeleteStackCommandArgs): Promise<void> {
+        const x = new DeleteStacksCommand();
+        await x.performCommand(command);
+    }
+
+    constructor(command?: Command) {
         super(command, commandName, commandDescription);
     }
 

--- a/src/state/persisted-state.ts
+++ b/src/state/persisted-state.ts
@@ -70,8 +70,7 @@ export class PersistedState {
         this.dirty = true;
     }
     public getValue(key: string): string | undefined {
-        if (this.state.values === undefined) { return undefined; }
-        return this.state.values[key];
+        return this.state.values?.[key];
     }
 
     public getTrackedTasks(tasksFileName: string): ITrackedTask[] {
@@ -96,9 +95,7 @@ export class PersistedState {
     }
 
     public getTarget(stackName: string, accountId: string, region: string): ICfnTarget | undefined {
-        if (!this.state.stacks) { return undefined; }
-
-        const accounts = this.state.stacks[stackName];
+        const accounts = this.state.stacks?.[stackName];
         if (!accounts) { return undefined; }
 
         const regions = accounts[accountId];
@@ -170,10 +167,7 @@ export class PersistedState {
     }
 
     public getBinding(type: string, logicalId: string): IBinding | undefined {
-        if (this.state.bindings === undefined) {
-            return undefined;
-        }
-        const typeDict = this.state.bindings[type];
+        const typeDict = this.state.bindings?.[type];
         if (!typeDict) { return undefined; }
 
         const result = typeDict[logicalId];

--- a/src/state/persisted-state.ts
+++ b/src/state/persisted-state.ts
@@ -86,7 +86,7 @@ export class PersistedState {
         return trackedForTasksFile;
     }
 
-    public setTrackedTasks(tasksFileName: string, trackedTasks: ITrackedTask[]) {
+    public setTrackedTasks(tasksFileName: string, trackedTasks: ITrackedTask[]): void {
         if (this.state.trackedTasks === undefined) {
             this.state.trackedTasks = {};
         }

--- a/src/state/persisted-state.ts
+++ b/src/state/persisted-state.ts
@@ -39,6 +39,7 @@ export class PersistedState {
             stacks: {},
             values: {},
             previousTemplate: '',
+            trackedTasks: {},
         });
         empty.dirty = true;
 
@@ -73,7 +74,30 @@ export class PersistedState {
         return this.state.values[key];
     }
 
+    public getTrackedTasks(tasksFileName: string): ITrackedTask[] {
+        if (this.state.trackedTasks === undefined) {
+            return [];
+        }
+
+        const trackedForTasksFile = this.state.trackedTasks[tasksFileName];
+        if (trackedForTasksFile === undefined) {
+            return [];
+        }
+        return trackedForTasksFile;
+    }
+
+    public setTrackedTasks(tasksFileName: string, trackedTasks: ITrackedTask[]) {
+        if (this.state.trackedTasks === undefined) {
+            this.state.trackedTasks = {};
+        }
+
+        this.state.trackedTasks[tasksFileName] = trackedTasks;
+        this.dirty = true;
+    }
+
     public getTarget(stackName: string, accountId: string, region: string): ICfnTarget | undefined {
+        if (!this.state.stacks) { return undefined; }
+
         const accounts = this.state.stacks[stackName];
         if (!accounts) { return undefined; }
 
@@ -84,7 +108,12 @@ export class PersistedState {
     }
 
     public setTarget(templateTarget: ICfnTarget): void {
+        if (this.state.stacks === undefined) {
+            this.state.stacks = {};
+        }
+
         let accounts = this.state.stacks[templateTarget.stackName];
+
         if (!accounts) {
             accounts = this.state.stacks[templateTarget.stackName] = {};
         }
@@ -141,6 +170,9 @@ export class PersistedState {
     }
 
     public getBinding(type: string, logicalId: string): IBinding | undefined {
+        if (this.state.bindings === undefined) {
+            return undefined;
+        }
         const typeDict = this.state.bindings[type];
         if (!typeDict) { return undefined; }
 
@@ -152,6 +184,9 @@ export class PersistedState {
     }
 
     public enumBindings(type: string): IBinding[] {
+        if (this.state.bindings === undefined) {
+            return [];
+        }
         const typeDict = this.state.bindings[type];
         if (!typeDict) { return []; }
 
@@ -162,6 +197,9 @@ export class PersistedState {
         return result;
     }
     public setUniqueBindingForType(binding: IBinding): void {
+        if (this.state.bindings === undefined) {
+            this.state.bindings = {};
+        }
         let typeDict: Record<string, IBinding> = this.state.bindings[binding.type];
         typeDict = this.state.bindings[binding.type] = {};
 
@@ -170,6 +208,9 @@ export class PersistedState {
     }
 
     public setBinding(binding: IBinding): void {
+        if (this.state.bindings === undefined) {
+            this.state.bindings = {};
+        }
         let typeDict: Record<string, IBinding> = this.state.bindings[binding.type];
         if (!typeDict) {
             typeDict = this.state.bindings[binding.type] = {};
@@ -181,6 +222,9 @@ export class PersistedState {
 
 
     public setBindingHash(type: string, logicalId: string, lastCommittedHash: string): void {
+        if (this.state.bindings === undefined) {
+            this.state.bindings = {};
+        }
         let typeDict: Record<string, IBinding> = this.state.bindings[type];
         if (!typeDict) {
             typeDict = this.state.bindings[type] = {};
@@ -249,6 +293,7 @@ export interface IState {
     bindings: Record<string, Record<string, IBinding>>;
     stacks: Record<string, Record<string, Record<string, ICfnTarget>>>;
     values: Record<string, string>;
+    trackedTasks: Record<string, ITrackedTask[]>;
     previousTemplate: string;
 }
 
@@ -266,4 +311,10 @@ export interface ICfnTarget {
     stackName: string;
     terminationProtection?: boolean;
     lastCommittedHash: string;
+}
+
+export interface ITrackedTask {
+    logicalName: string;
+    physicalIdForCleanup: string;
+    type: string;
 }

--- a/test/integration-tests/nested-ou.test.ts
+++ b/test/integration-tests/nested-ou.test.ts
@@ -146,57 +146,57 @@ describe('when manipulating ous', () => {
         unlinkSync(templateWithoutParentPath);
     });
 
-//     test('can delete parent and keep child with accounts ', async () => {
+    test('can delete parent and keep child with accounts ', async () => {
 
-//         const source = readFileSync(templateFileName).toString('utf-8');
+        const source = readFileSync(templateFileName).toString('utf-8');
 
-//         const templateWithAccountsInOUsFileName = templateFileName.replace('.yml', '-with-accounts.yml');
+        const templateWithAccountsInOUsFileName = templateFileName.replace('.yml', '-with-accounts.yml');
 
-//         const withAccounts = `
-//   ParentOU:
-//     Type: OC::ORG::OrganizationalUnit
-//     Properties:
-//       OrganizationalUnitName: parent
-//       OrganizationalUnits: !Ref ChildOU
-//       Accounts: !Ref ${templateRoot.organizationSection.accounts[0].logicalId}
+        const withAccounts = `
+  ParentOU:
+    Type: OC::ORG::OrganizationalUnit
+    Properties:
+      OrganizationalUnitName: parent
+      OrganizationalUnits: !Ref ChildOU
+      Accounts: !Ref ${templateRoot.organizationSection.accounts[0].logicalId}
 
-//   ChildOU:
-//     Type: OC::ORG::OrganizationalUnit
-//     Properties:
-//       OrganizationalUnitName: child
-//       Accounts: !Ref ${templateRoot.organizationSection.accounts[1].logicalId}`;
+  ChildOU:
+    Type: OC::ORG::OrganizationalUnit
+    Properties:
+      OrganizationalUnitName: child
+      Accounts: !Ref ${templateRoot.organizationSection.accounts[1].logicalId}`;
 
-//         let sourceRewritten = source.replace(/\s*- !Ref ${templateRoot.organizationSection.accounts[0].logicalId}/, '');
-//         sourceRewritten = sourceRewritten.replace(/\s*- !Ref ${templateRoot.organizationSection.accounts[1].logicalId}/, '');
+        let sourceRewritten = source.replace(/\s*- !Ref ${templateRoot.organizationSection.accounts[0].logicalId}/, '');
+        sourceRewritten = sourceRewritten.replace(/\s*- !Ref ${templateRoot.organizationSection.accounts[1].logicalId}/, '');
 
-//         writeFileSync(templateWithAccountsInOUsFileName, sourceRewritten + withAccounts);
+        writeFileSync(templateWithAccountsInOUsFileName, sourceRewritten + withAccounts);
 
-//         spawnProcess('delete parent, keep child', 'ts-node', ['cli.ts', 'update', templateWithAccountsInOUsFileName,
-//             '--profile', awsProfileForTests,
-//             '--state-bucket-name', bucketName,
-//             '--verbose',
-//             '--print-stack']);
+        spawnProcess('delete parent, keep child', 'ts-node', ['cli.ts', 'update', templateWithAccountsInOUsFileName,
+            '--profile', awsProfileForTests,
+            '--state-bucket-name', bucketName,
+            '--verbose',
+            '--print-stack']);
 
-//         const templateWithoutParentPath = templateFileName.replace('.yml', '-without-parent.yml');
-//         const withoutParent = `
-//   ChildOU:
-//     Type: OC::ORG::OrganizationalUnit
-//     Properties:
-//       OrganizationalUnitName: child`
+        const templateWithoutParentPath = templateFileName.replace('.yml', '-without-parent.yml');
+        const withoutParent = `
+  ChildOU:
+    Type: OC::ORG::OrganizationalUnit
+    Properties:
+      OrganizationalUnitName: child`
 
-//         writeFileSync(templateWithoutParentPath, source + withoutParent);
+        writeFileSync(templateWithoutParentPath, source + withoutParent);
 
-//         spawnProcess('delete parent, keep child', 'ts-node', ['cli.ts', 'update', templateWithoutParentPath,
-//             '--profile', awsProfileForTests,
-//             '--state-bucket-name', bucketName,
-//             '--verbose',
-//             '--print-stack']);
+        spawnProcess('delete parent, keep child', 'ts-node', ['cli.ts', 'update', templateWithoutParentPath,
+            '--profile', awsProfileForTests,
+            '--state-bucket-name', bucketName,
+            '--verbose',
+            '--print-stack']);
 
-//         await expectOUInRoot(true, false);
+        await expectOUInRoot(true, false);
 
-//         unlinkSync(templateWithAccountsInOUsFileName);
-//         unlinkSync(templateWithoutParentPath);
-//     });
+        unlinkSync(templateWithAccountsInOUsFileName);
+        unlinkSync(templateWithoutParentPath);
+    });
 
     test('can delete child and keep parent ', async () => {
         const templateWithoutChildPath = templateFileName.replace('.yml', '-without-child.yml');

--- a/test/unit-tests/build-tasks/build-configuration.test.ts
+++ b/test/unit-tests/build-tasks/build-configuration.test.ts
@@ -1,6 +1,6 @@
 import Sinon from 'sinon';
 import { IBuildTask, IUpdateStackTaskConfiguration } from '~build-tasks/build-configuration';
-import { BuildTaskProvider } from '~build-tasks/build-task-provider';
+import { BuildTaskProvider, BaseStacksTask } from '~build-tasks/build-task-provider';
 import { ICommandArgs } from '~commands/base-command';
 import { IUpdateStacksCommandArgs, UpdateStacksCommand } from '~commands/update-stacks';
 import { ConsoleUtil } from '../../../src/console-util';
@@ -32,6 +32,9 @@ describe('when creating build configuration with duplicate stack name', () => {
         expect(task).toBeDefined();
     });
 
+    test('stackname is used for physicalIdForCleanup', () => {
+        expect(task.physicalIdForCleanup).toBe((task as BaseStacksTask).stackName);
+    });
     test('template and stackname are passed to updateStackResources', async () => {
         await task.perform();
         const commandArgs = updateStacksResoruces.lastCall.args[0] as IUpdateStacksCommandArgs;

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -1,0 +1,280 @@
+import { Command, Option } from 'commander';
+import { PerformTasksCommand, IPerformTasksCommandArgs } from '~commands/perform-tasks';
+import { BuildConfiguration, IUpdateOrganizationTaskConfiguration, IBuildTask, IBuildTaskConfiguration } from '~build-tasks/build-configuration';
+import { PersistedState, ITrackedTask } from '~state/persisted-state';
+import { BuildRunner } from '~build-tasks/build-runner';
+import { BuildTaskProvider } from '~build-tasks/build-task-provider';
+import { ConsoleUtil } from '../../../src/console-util';
+import { DeleteStacksCommand } from '~commands/index';
+
+describe('when creating perform-tasks command', () => {
+    let command: PerformTasksCommand;
+    let commanderCommand: Command;
+    let subCommanderCommand: Command;
+
+    beforeEach(() => {
+        commanderCommand = new Command('root');
+        command = new PerformTasksCommand(commanderCommand);
+        subCommanderCommand = commanderCommand.commands[0];
+    });
+
+    test('perform-tasks command is created', () => {
+        expect(command).toBeDefined();
+        expect(subCommanderCommand).toBeDefined();
+        expect(subCommanderCommand.name()).toBe('perform-tasks');
+    });
+
+    test('perform-tasks command has description', () => {
+       expect(subCommanderCommand).toBeDefined();
+       expect(subCommanderCommand.description()).toBeDefined();
+    });
+
+    test('perform-tasks command has file as first argument', () => {
+        const firstArg = subCommanderCommand._args[0];
+        expect(firstArg).toBeDefined();
+        expect(firstArg.required).toBe(true);
+        expect(firstArg.name).toBe('tasks-file');
+    });
+
+    test('perform-tasks has state bucket parameter with correct default', () => {
+        const opts: Option[] = subCommanderCommand.options;
+        const stateBucketOpt = opts.find((x) => x.long === '--state-bucket-name');
+        expect(stateBucketOpt).toBeDefined();
+        expect(subCommanderCommand.stateBucketName).toBe('organization-formation-${AWS::AccountId}');
+    });
+
+    test('perform-tasks has state file parameter with correct default', () => {
+        const opts: Option[] = subCommanderCommand.options;
+        const stateObjectOpt = opts.find((x) => x.long === '--state-object');
+        expect(stateObjectOpt).toBeDefined();
+        expect(subCommanderCommand.stateObject).toBe('state.json');
+    });
+
+    test('perform-tasks has logical name parameter with correct default', () => {
+        const opts: Option[] = subCommanderCommand.options;
+        const logicalNameOpt = opts.find((x) => x.long === '--logical-name');
+        expect(logicalNameOpt).toBeDefined();
+        expect(subCommanderCommand.logicalName).toBe('default');
+    });
+
+    test('perform-tasks has perform cleanup parameter with correct default', () => {
+        const opts: Option[] = subCommanderCommand.options;
+        const performCleanupOpt = opts.find((x) => x.long === '--perform-cleanup');
+        expect(performCleanupOpt).toBeDefined();
+        expect(subCommanderCommand.performCleanup).toBeFalsy();
+    });
+});
+
+
+
+describe('when executing perform-tasks command', () => {
+    let command: PerformTasksCommand;
+    let commanderCommand: Command;
+    let subCommanderCommand: Command;
+    let buildConfigurationEnumConfigMock: jest.SpyInstance;
+    let buildConfigurationEnumTasksMock: jest.SpyInstance;
+    let performTasksGetStateMock: jest.SpyInstance;
+    let buildRunnerRunTasksMock: jest.SpyInstance;
+    let commandArgs: IPerformTasksCommandArgs;
+    let configs: IBuildTaskConfiguration[];
+    let tasks: IBuildTask[];
+    let state: PersistedState;
+
+    beforeEach(() => {
+
+        configs = [{
+            Type: 'update-organization',
+            LogicalName: 'updateOrg',
+            Template: 'organization.yml',
+        } as IUpdateOrganizationTaskConfiguration]
+
+
+        tasks = [{
+            name: 'updateOrg',
+            type: 'update-organization',
+            childTasks: [],
+            perform: async () => {},
+            isDependency: () => false,
+        }]
+
+        state = PersistedState.CreateEmpty('123123123123');
+
+        buildConfigurationEnumConfigMock = jest.spyOn(BuildConfiguration.prototype, 'enumBuildConfiguration').mockReturnValue(configs);
+        buildConfigurationEnumTasksMock = jest.spyOn(BuildConfiguration.prototype, 'enumBuildTasks').mockReturnValue(tasks);
+        performTasksGetStateMock = jest.spyOn(PerformTasksCommand.prototype, 'getState').mockReturnValue(Promise.resolve(state));
+        buildRunnerRunTasksMock = jest.spyOn(BuildRunner, 'RunTasks').mockImplementation();
+
+        commanderCommand = new Command('root');
+        command = new PerformTasksCommand(commanderCommand);
+        subCommanderCommand = commanderCommand.commands[0];
+
+        commandArgs = {maxConcurrentStacks: 1, failedStacksTolerance: 0, maxConcurrentTasks: 1, failedTasksTolerance: 0, tasksFile: 'tasks.yml', logicalName: 'default'} as IPerformTasksCommandArgs;
+    });
+
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    })
+    test('BuildConfiguration called to enum config', async () => {
+        await command.performCommand(commandArgs);
+        expect(buildConfigurationEnumConfigMock).toHaveBeenCalledTimes(1);
+        expect(buildConfigurationEnumConfigMock).toHaveBeenCalledWith('tasks.yml');
+    });
+
+    test('BuildConfiguration called to enum tasks', async () => {
+        await command.performCommand(commandArgs);
+        expect(buildConfigurationEnumTasksMock).toHaveBeenCalledTimes(1);
+        expect(buildConfigurationEnumTasksMock).toHaveBeenCalledWith(commandArgs);
+    });
+
+    test('getState called to get state', async () => {
+        await command.performCommand(commandArgs);
+        expect(performTasksGetStateMock).toHaveBeenCalledTimes(1);
+        expect(performTasksGetStateMock).toHaveBeenCalledWith(commandArgs);
+    });
+
+    test('perform tasks is called once', async () => {
+        await command.performCommand(commandArgs);
+        expect(buildRunnerRunTasksMock).toHaveBeenCalledTimes(1);
+        expect(buildRunnerRunTasksMock).toHaveBeenCalledWith(tasks, 1, 0);
+    });
+
+    describe('with update stacks tasks', () => {
+
+        let stateSaveMock: jest.SpyInstance;
+
+        beforeEach(() => {
+            const updateStacks: IBuildTask[] = [
+                { name: 'updateStacks1', type: 'update-stacks', childTasks: [], physicalIdForCleanup: 'stack-name-1', perform: async () => {}, isDependency: () => false },
+                { name: 'updateStacks2', type: 'update-stacks', childTasks: [], physicalIdForCleanup: 'stack-name-2', perform: async () => {}, isDependency: () => false }
+            ];
+
+            stateSaveMock = jest.spyOn(PersistedState.prototype, 'save').mockImplementation();
+
+            tasks = tasks.concat(updateStacks);
+            buildConfigurationEnumTasksMock = jest.spyOn(BuildConfiguration.prototype, 'enumBuildTasks').mockReturnValue(tasks);
+        });
+
+        test('BuildConfiguration called to enum tasks', async () => {
+            await command.performCommand(commandArgs);
+            expect(buildConfigurationEnumTasksMock).toHaveBeenCalledTimes(1);
+            expect(buildConfigurationEnumTasksMock).toHaveBeenCalledWith(commandArgs);
+        });
+
+        test('perform tasks is called once', async () => {
+            await command.performCommand(commandArgs);
+            expect(buildRunnerRunTasksMock).toHaveBeenCalledTimes(1);
+            expect(buildRunnerRunTasksMock).toHaveBeenCalledWith(tasks, 1, 0);
+        });
+
+        test('stacks are stored as tracked tasks', async () => {
+            await command.performCommand(commandArgs);
+            const trackedTasks = state.getTrackedTasks(commandArgs.logicalName);
+            expect(trackedTasks).toBeDefined();
+            expect(trackedTasks.length).toBe(2);
+            expect(trackedTasks[0].physicalIdForCleanup).toBe('stack-name-1');
+            expect(trackedTasks[1].physicalIdForCleanup).toBe('stack-name-2');
+        });
+
+        test('state is saved', async () => {
+            await command.performCommand(commandArgs);
+            expect(stateSaveMock).toHaveBeenCalledTimes(1);
+        });
+
+        describe('and stack to clean up', () => {
+            let deleteStacksCommandPerformMock: jest.SpyInstance;
+            let logWarningMock: jest.SpyInstance;
+            let logInfoMock: jest.SpyInstance;
+            let buildTaskProviderCreateDeleteTaskMock: jest.SpyInstance;
+
+            beforeEach(() => {
+                const trackedTasks: ITrackedTask[] = [
+                    { logicalName: 'updateStacks1', type: 'update-stacks', physicalIdForCleanup: 'stack-name-1' },
+                    { logicalName: 'updateStacks2', type: 'update-stacks', physicalIdForCleanup: 'stack-name-2' },
+                    { logicalName: 'updateStacks3', type: 'update-stacks', physicalIdForCleanup: 'stack-name-3' },
+                ]
+
+                state.setTrackedTasks('default', trackedTasks);
+                buildTaskProviderCreateDeleteTaskMock = jest.spyOn(BuildTaskProvider, 'createDeleteTask');
+                deleteStacksCommandPerformMock = jest.spyOn(DeleteStacksCommand, 'Perform').mockImplementation();
+
+                logWarningMock = jest.spyOn(ConsoleUtil, 'LogWarning').mockImplementation();
+                logInfoMock = jest.spyOn(ConsoleUtil, 'LogInfo').mockImplementation();
+            });
+
+            test('perform tasks is called twice', async () => {
+                await command.performCommand(commandArgs);
+                expect(buildRunnerRunTasksMock).toHaveBeenCalledTimes(2);
+                expect(buildRunnerRunTasksMock).toHaveBeenCalledWith(tasks, 1, 0);
+            });
+
+            test('stacks are stored as tracked tasks', async () => {
+                await command.performCommand(commandArgs);
+                const trackedTasks = state.getTrackedTasks(commandArgs.logicalName);
+                expect(trackedTasks).toBeDefined();
+                expect(trackedTasks.length).toBe(2);
+                expect(trackedTasks[0].physicalIdForCleanup).toBe('stack-name-1');
+                expect(trackedTasks[1].physicalIdForCleanup).toBe('stack-name-2');
+            });
+
+            test('delete task is created for previously tracked task', async () => {
+                await command.performCommand(commandArgs);
+                expect(buildTaskProviderCreateDeleteTaskMock).toHaveBeenCalledTimes(1);
+                expect(buildTaskProviderCreateDeleteTaskMock).toHaveBeenCalledWith('updateStacks3', 'update-stacks', 'stack-name-3', commandArgs);
+            });
+
+            test('delete task has perform cleanup set to false', async () => {
+                await command.performCommand(commandArgs);
+                expect(buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.performCleanup).toBeFalsy();;
+            });
+
+            test('delete task with log warnings', async () => {
+                await command.performCommand(commandArgs);
+
+                expect(logWarningMock).toHaveBeenCalledTimes(0);
+                await buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.perform();
+
+                expect(logWarningMock).toHaveBeenCalledTimes(8);
+            });
+
+            test('delete stacks command is not called', async () => {
+                await command.performCommand(commandArgs);
+                await buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.perform();
+
+                expect(deleteStacksCommandPerformMock).toHaveBeenCalledTimes(0);
+            })
+
+            describe('and perform cleanup flag', () => {
+
+                test('delete stacks command is called', async () => {
+                    await command.performCommand({...commandArgs, performCleanup: true });
+                    await buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.perform();
+
+                    expect(deleteStacksCommandPerformMock).toHaveBeenCalledTimes(1);
+
+                    const call = deleteStacksCommandPerformMock.mock.calls[0];
+                    expect(call[0].stackName).toBe('stack-name-3');
+                })
+                test('delete task with not log warnings', async () => {
+                    await command.performCommand({...commandArgs, performCleanup: true });
+                    await buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.perform();
+
+
+                    expect(logWarningMock).toHaveBeenCalledTimes(0);
+                    await buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.perform();
+
+                    expect(logWarningMock).toHaveBeenCalledTimes(0);
+                });
+
+                test('info message is logged', async () => {
+                    await command.performCommand({...commandArgs, performCleanup: true });
+                    await buildTaskProviderCreateDeleteTaskMock.mock.results[0].value.perform();
+
+                    expect(logInfoMock).toHaveBeenCalledTimes(1);
+                    expect(logInfoMock).toHaveBeenCalledWith(expect.stringContaining('stack-name-3'));
+                    expect(logInfoMock).toHaveBeenCalledWith(expect.stringContaining('delete'));
+                });
+            });
+        });
+    });
+});

--- a/test/unit-tests/commands/update-stacks.test.ts
+++ b/test/unit-tests/commands/update-stacks.test.ts
@@ -312,7 +312,6 @@ describe('when executing update-stacks command', () => {
         afterEach(()=> {
             sandbox.restore();
         });
-
         test('parameters are passed to binder', async () => {
             await command.performCommand(commandArgs);
             expect(enumTasks.getCall(0).thisValue).toBeDefined();


### PR DESCRIPTION
added `--perform-cleanup` flag to `perform-tasks` command.
stacks that were previously deployed as part of the tasks-file will be deleted automatically if this option is specified.

added `--logical-name` option to `perform-tasks` command in order to use `perform-tasks` command on multiple files against the same aws org.

if `--perform-cleanup` is not specified a warning will be printed to inform the user that he/she should manually delete the stacks or use `--perform-cleanup` option.