### PR TITLE
add option to prefix child tasks in include

### DIFF
--- a/src/build-tasks/tasks/include-task.ts
+++ b/src/build-tasks/tasks/include-task.ts
@@ -18,9 +18,15 @@ export class IncludeTaskProvider implements IBuildTaskProvider<IIncludeTaskConfi
 
         const dir = path.dirname(config.FilePath);
         const taskFilePath = path.join(dir, config.Path);
-        const parameters: Record<string, any> = {...command.parsedParameters, ...(config.Parameters ?? {})};
+        const parameters: Record<string, any> = { ...command.parsedParameters, ...(config.Parameters ?? {}) };
         const buildConfig = new BuildConfiguration(taskFilePath, parameters);
         const childTasks = buildConfig.enumBuildTasks(command as IPerformTasksCommandArgs);
+
+        if (config.SubtaskPrefix !== undefined) {
+            childTasks.forEach(child => {
+                child.name = config.SubtaskPrefix.concat(child.name);
+            });
+        }
 
         return {
             type: config.Type,
@@ -43,9 +49,15 @@ export class IncludeTaskProvider implements IBuildTaskProvider<IIncludeTaskConfi
 
         const dir = path.dirname(config.FilePath);
         const taskFilePath = path.join(dir, config.Path);
-        const parameters: Record<string, any> = {...command.parsedParameters, ...(config.Parameters ?? {})};
+        const parameters: Record<string, any> = { ...command.parsedParameters, ...(config.Parameters ?? {}) };
         const buildConfig = new BuildConfiguration(taskFilePath, parameters);
         const childTasks = buildConfig.enumValidationTasks(command as IPerformTasksCommandArgs);
+
+        if (config.SubtaskPrefix !== undefined) {
+            childTasks.forEach(child => {
+                child.name = config.SubtaskPrefix.concat(child.name);
+            });
+        }
 
         return {
             type: config.Type,
@@ -67,4 +79,5 @@ export interface IIncludeTaskConfiguration extends IBuildTaskConfiguration {
     Parameters: Record<string, any>;
     MaxConcurrentTasks?: number;
     FailedTaskTolerance?: number;
+    SubtaskPrefix?: string;
 }

--- a/test/unit-tests/build-tasks/build-configuration.test.ts
+++ b/test/unit-tests/build-tasks/build-configuration.test.ts
@@ -5,8 +5,7 @@ import { IUpdateStacksCommandArgs, UpdateStacksCommand } from '~commands/update-
 import { ConsoleUtil } from '~util/console-util';
 import { IUpdateStackTaskConfiguration } from '~build-tasks/tasks/update-stacks-task';
 import { IPerformTasksCommandArgs } from '~commands/index';
-
-
+import { IIncludeTaskConfiguration } from '~build-tasks/tasks/include-task'
 
 describe('when resolving tasks from configuration', () => {
     let buildFile: any | IBuildFile;
@@ -184,5 +183,39 @@ describe('when creating build configuration with duplicate stack name', () => {
         expect(commandKeys.length).toBe(4);
         expect(commandKeys).toEqual(expect.arrayContaining(['stackName']));
         expect(commandArgs.stackName).toBe('stack');
+    });
+});
+
+describe('when creating build configuration with include task', () => {
+    let task: IBuildTask;
+    let updateStacksResources: sinon.SinonStub;
+    const sandbox = Sinon.createSandbox();
+    beforeEach(() => {
+        const config: IIncludeTaskConfiguration = {
+            Type: 'include',
+            Path: './test/resources/tasks/build-tasks.yml',
+            FilePath: './.',
+            LogicalName: 'task',
+            MaxConcurrentTasks: 1,
+            SubtaskPrefix: 'prefix-',
+            FailedTaskTolerance: 10,
+            Parameters: { Key: 'Val' },
+        };
+        task = BuildTaskProvider.createBuildTask(config, {} as IPerformTasksCommandArgs);
+
+        updateStacksResources = sandbox.stub(UpdateStacksCommand, 'Perform');
+        sandbox.stub(ConsoleUtil, 'LogInfo')
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+    test('creates task', () => {
+        expect(task).toBeDefined();
+    });
+    test('child task name is prefixed', () => {
+        task.childTasks.forEach(childTask => {
+            expect(childTask.name.startsWith('prefix-'))
+        });
     });
 });


### PR DESCRIPTION
I didn't quite understand the testing framework yet and couldn't get the integration tests working. 

I added an attribute SubtaskPrefix as opposed to prefixing childtasks by default with the name of the parent task for backwards compatibility. In a major release I would remove the option and prefix by default