### PR TITLE
Enable running 'update-cdk' tasks for multiple regions

### DIFF
--- a/docs/cloudformation-resources.md
+++ b/docs/cloudformation-resources.md
@@ -119,12 +119,12 @@ In the example above the resource Bucket will be created for Account1 and Accoun
 There is a lot of other ways to specify an account binding though:
 
 
-|Attribue |Value|Remarks|
+|Attribute |Value|Remarks|
 |:---|:---|:---|
 |Region|String or list of String|Resource will be created in all the specified resources.|
 |Account|literal '*'|Resource will be created in all accounts **except** for the master account.|
 ||!Ref or list of !Ref|Resource will be created in [Accounts](#account) that are referred to.|
-|OrganizationalUnit|!Ref or list of !Ref|Resource will be created in all accounts that below to the [OrganizationalUnits](#organizationalunit) that are refered to. This includes accounts created within nested OU's|
+|OrganizationalUnit|!Ref or list of !Ref|Resource will be created in all accounts that below to the [OrganizationalUnits](#organizationalunit) that are referred to. This includes accounts created within nested OU's|
 |ExcludeAccount|!Ref or list of !Ref|Resource will **not** be created in [Accounts](#account) that are referred to.|
 |IncludeMasterAccount|``true`` or ``false``| If ``true``, resource will be created in the organizational master account.|
 |AccountsWithTag|tag-name|Resource will be created in all accounts that have a tag specified with tag-name.|

--- a/docs/organization-resources.md
+++ b/docs/organization-resources.md
@@ -240,7 +240,6 @@ OrganizationalUnit is an AWS Organizational Unit within your organization and ca
 |ServiceControlPolicies|Reference or list of References |This property is optional. <br/><br/>Reference or list of References to [ServiceControlPolicy](#servicecontrolpolicy) resources that must be enforced on all accounts (including master account) within the AWS Organization.|
 |OrganizationalUnits|Reference or list of References |This property is optional. <br/><br/>Reference or list of References to [OrganizationalUnit](#OrganizationalUnit) resources that must be nested within the current OrganizationalUnit.|
 
-**Note** It is currently not supported to nest organizational units (have an OU as the parent of another OU). It is also not possible to add a MasterAccount resource to an OU.
 
 **!Ref** Returns the physical id of the OrganizationalUnit resource.
 

--- a/src/plugin/impl/cdk-build-task-plugin.ts
+++ b/src/plugin/impl/cdk-build-task-plugin.ts
@@ -165,8 +165,13 @@ export class CdkBuildTaskPlugin implements IBuildTaskPlugin<ICdkBuildTaskConfig,
 
     static GetEnvironmentVariables(target: IGenericTarget<ICdkTask>): Record<string, string> {
         return {
+            // Note: The CDK_DEFAULT_* variables will be overwritten by the cdk cli. Use the
+            // CDK_DEPLOY_* variables instead as documented in:
+            // https://docs.aws.amazon.com/cdk/latest/guide/environments.html
             CDK_DEFAULT_REGION: target.region,
             CDK_DEFAULT_ACCOUNT: target.accountId,
+            CDK_DEPLOY_REGION: target.region,
+            CDK_DEPLOY_ACCOUNT: target.accountId,
         };
     }
 

--- a/test/integration-tests/cdk-task.test.ts
+++ b/test/integration-tests/cdk-task.test.ts
@@ -76,6 +76,16 @@ describe('when calling org-formation perform tasks', () => {
         expect(noAccount).toBeUndefined();
     });
 
+    test('after deploy 2 targets CDK_DEPLOY_REGION and CDK_DEPLOY_ACCOUNT are set', () => {
+        const contexts: ExecOptions[] = [spawnProcessAfterDeploy2Targets.calls[0][1], spawnProcessAfterDeploy2Targets.calls[1][1]];
+
+        const noRegion = contexts.find(x => x.env['CDK_DEPLOY_REGION'] === undefined);
+        const noAccount = contexts.find(x => x.env['CDK_DEPLOY_ACCOUNT'] === undefined);
+
+        expect(noRegion).toBeUndefined();
+        expect(noAccount).toBeUndefined();
+    });
+
 
     test('when updating with parameters, parameters are passed to CDK invocation', () => {
         const command0 = spawnProcessAfterUpdateWithParameters.calls[0][0];


### PR DESCRIPTION
This is a pull request for the issue discussed on [Slack](https://org-formation.slack.com/archives/CT6JQ05AA/p1595022047014600).

**Current behavior:**
At the moment the _update-cdk_ plugin sets the environment variables _CDK_DEFAULT_REGION_ and _CDK_DEFAULT_ACCOUNT_. However, the CDK CLI overwrites these variables using the same account/region resolution strategy as the AWS CLI. This means that the CDK workload cannot determine the correct region if the region is different from the region in which the org-formation tasks are executed. 

**Desired behavior:**
The CDK workload should be able to determine the correct region and account for deployment.

**Solution**
Add _CDK_DEPLOY_ACCOUNT_ and _CDK_DEPLOY_REGION_ to environment variables for _update-cdk_ tasks as suggested in the [AWS CDK documentation](https://docs.aws.amazon.com/cdk/latest/guide/environments.html). The CDK workload can then use these environment variables like this:

```
#!/usr/bin/env node
import { App } from '@aws-cdk/core';
import { MyStack } from './my-stack';

const app = new App();

new MyStack(app, 'MyStack', {
    env: {
        account: process.env.CDK_DEPLOY_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT,
        region: process.env.CDK_DEPLOY_REGION || process.env.CDK_DEFAULT_REGION,
    },
});
```