### PR TITLE
IAM Policy Updates

### DIFF
--- a/resources/orgformation-codepipeline.yml
+++ b/resources/orgformation-codepipeline.yml
@@ -46,6 +46,16 @@ Resources:
             Version: 2012-10-17
             Statement:
             - Effect: Allow
+              Action:
+                - "ec2:DescribeRegions"
+              Resource:
+                - "*"
+            - Effect: Allow
+              Action:
+                - "sts:AssumeRole"
+              Resource:
+                - "arn:aws:iam::*:role/OrganizationFormationBuildAccessRole"
+            - Effect: Allow
               Resource:
               - !GetAtt OrgBuildLogGroup.Arn
               - !Sub '${OrgBuildLogGroup.Arn}:*'

--- a/resources/orgformation-codepipeline.yml
+++ b/resources/orgformation-codepipeline.yml
@@ -34,6 +34,9 @@ Resources:
               Service: codebuild.amazonaws.com
             Action:
               - sts:AssumeRole
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${resourcePrefix}-build"
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AdministratorAccess' # see: https://github.com/org-formation/org-formation-cli/blob/master/docs/least-priviledge.md
@@ -278,6 +281,9 @@ Resources:
                 - events.amazonaws.com
             Action:
               - sts:AssumeRole
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${resourcePrefix}-pipeline-event-rule"
       Description: !Sub Used to trigger the pipeline attached to the ${OrgRepo.Name} repository
       Path: /
       Policies:

--- a/resources/orgformation-codepipeline.yml
+++ b/resources/orgformation-codepipeline.yml
@@ -52,6 +52,11 @@ Resources:
                 - "*"
             - Effect: Allow
               Action:
+                - "events:PutEvents"
+              Resource:
+                - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default'
+            - Effect: Allow
+              Action:
                 - "sts:AssumeRole"
               Resource:
                 - "arn:aws:iam::*:role/OrganizationFormationBuildAccessRole"

--- a/resources/orgformation-codepipeline.yml
+++ b/resources/orgformation-codepipeline.yml
@@ -16,23 +16,6 @@ Parameters:
 
 Resources:
 
-  StateBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref stateBucketName
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: AccessFromAccount
-            Principal:
-              AWS: !Ref 'AWS::AccountId'
-            Effect: Allow
-            Action:
-              - s3:*
-            Resource:
-              - !Sub 'arn:aws:s3:::${stateBucketName}'
-              - !Sub 'arn:aws:s3:::${stateBucketName}/*'
-
   OrgBuildLogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:


### PR DESCRIPTION
I would like to propose following changes to tighten IAM policies. None of these changes should have any noticeable effect.

- Current S3 state bucket policy does not actually do anything because the bucket and principals accessing it are in the same account, so effective permissions are granted by identity policy and not the bucket policy. Removing it simply reduces the amount of policies that need to be audited.
- Adding "aws:SourceArn" helps mitigate confused deputy attacks. We explicitly specify resources that can assume that role.
- Adding permissions to OrgBuildRole helps CodeBuild to continue running successfully even if AdministratorAccess access policy is removed from that role.