### PR TITLE
Fix/terraform list

### DIFF
--- a/src/plugin/impl/tf-apply-task-plugin.ts
+++ b/src/plugin/impl/tf-apply-task-plugin.ts
@@ -182,8 +182,15 @@ export class TfBuildTaskPlugin implements IBuildTaskPlugin<ITfBuildTaskConfig, I
     static GetParametersAsArgument(parameters: Record<string, any>): string {
         if (!parameters) { return ''; }
         const entries = Object.entries(parameters);
-        return entries.reduce((prev, curr) => prev + ` -var '${curr[0]}=${curr[1]}'`, '');
+    
+        return entries.reduce((prev, [key, value]) => {
+            if (Array.isArray(value)) {
+                value = JSON.stringify(value);
+            }
+            return prev + ` -var '${key}=${value}'`;
+        }, '');
     }
+    
 
     static GetBackendConfigAsArgument(backendConfig: Record<string, any>): string {
         if (!backendConfig) { return ''; }

--- a/src/plugin/impl/tf-apply-task-plugin.ts
+++ b/src/plugin/impl/tf-apply-task-plugin.ts
@@ -182,7 +182,7 @@ export class TfBuildTaskPlugin implements IBuildTaskPlugin<ITfBuildTaskConfig, I
     static GetParametersAsArgument(parameters: Record<string, any>): string {
         if (!parameters) { return ''; }
         const entries = Object.entries(parameters);
-        return entries.reduce((prev, curr) => prev + ` -var "${curr[0]}=${curr[1]}"`, '');
+        return entries.reduce((prev, curr) => prev + ` -var '${curr[0]}=${curr[1]}'`, '');
     }
 
     static GetBackendConfigAsArgument(backendConfig: Record<string, any>): string {

--- a/src/plugin/impl/tf-apply-task-plugin.ts
+++ b/src/plugin/impl/tf-apply-task-plugin.ts
@@ -191,7 +191,6 @@ export class TfBuildTaskPlugin implements IBuildTaskPlugin<ITfBuildTaskConfig, I
         }, '');
     }
     
-
     static GetBackendConfigAsArgument(backendConfig: Record<string, any>): string {
         if (!backendConfig) { return ''; }
         const entries = Object.entries(backendConfig);

--- a/src/plugin/impl/tf-apply-task-plugin.ts
+++ b/src/plugin/impl/tf-apply-task-plugin.ts
@@ -182,7 +182,7 @@ export class TfBuildTaskPlugin implements IBuildTaskPlugin<ITfBuildTaskConfig, I
     static GetParametersAsArgument(parameters: Record<string, any>): string {
         if (!parameters) { return ''; }
         const entries = Object.entries(parameters);
-    
+
         return entries.reduce((prev, [key, value]) => {
             if (Array.isArray(value)) {
                 value = JSON.stringify(value);
@@ -190,7 +190,7 @@ export class TfBuildTaskPlugin implements IBuildTaskPlugin<ITfBuildTaskConfig, I
             return prev + ` -var '${key}=${value}'`;
         }, '');
     }
-    
+
     static GetBackendConfigAsArgument(backendConfig: Record<string, any>): string {
         if (!backendConfig) { return ''; }
         const entries = Object.entries(backendConfig);


### PR DESCRIPTION
When using a list as parameter (eg `myvar = [ "val1", "val2" ]`) the resulting command was `-var 'myvar=val1,val2'` which terraform reads as variables, which are not allowed for variable values. 

With this change, both strings and "lists" (Arrays) are read correctly.



