### PR TITLE
fix: initialize global states in validate-tasks and print-tasks to allow the usage of the correct roles to source the remote s3 templates

### DIFF
--- a/src/commands/print-tasks.ts
+++ b/src/commands/print-tasks.ts
@@ -7,6 +7,7 @@ import { BuildRunner } from '~build-tasks/build-runner';
 import { Validator } from '~parser/validator';
 import { AwsUtil } from '~util/aws-util';
 import { ConsoleUtil } from '~util/console-util';
+import { GlobalState } from '~util/global-state';
 
 const commandName = 'print-tasks <tasksFile>';
 const commandDescription = 'Will print out all cloudformation templates that will be deployed by tasksFile';
@@ -60,7 +61,10 @@ export class PrintTasksCommand extends BaseCliCommand<IPrintTasksCommandArgs> {
 
         command.parsedParameters = this.parseCfnParameters(command.parameters);
         const config = new BuildConfiguration(tasksFile, command.parsedParameters, command.TemplatingContext);
-        await config.fixateOrganizationFile(command);
+        const template = await config.fixateOrganizationFile(command);
+        const state = await this.getState(command);
+
+        GlobalState.Init(state, template);
 
         const printTasks = config.enumPrintTasks(command);
 

--- a/src/commands/validate-tasks.ts
+++ b/src/commands/validate-tasks.ts
@@ -6,6 +6,7 @@ import { BuildRunner } from '~build-tasks/build-runner';
 import { Validator } from '~parser/validator';
 import { AwsUtil } from '~util/aws-util';
 import { ConsoleUtil } from '~util/console-util';
+import { GlobalState } from '~util/global-state';
 
 const commandName = 'validate-tasks <tasksFile>';
 const commandDescription = 'Will validate the tasks file, including configured tasks';
@@ -55,8 +56,10 @@ export class ValidateTasksCommand extends BaseCliCommand<IPerformTasksCommandArg
 
         command.parsedParameters = this.parseCfnParameters(command.parameters);
         const config = new BuildConfiguration(tasksFile, command.parsedParameters, command.TemplatingContext);
+        const template = await config.fixateOrganizationFile(command);
+        const state = await this.getState(command);
 
-        await config.fixateOrganizationFile(command);
+        GlobalState.Init(state, template);
         const validationTasks = config.enumValidationTasks(command);
 
         if (command.match) {


### PR DESCRIPTION
# Problem

When using a template stored remotely in S3, the `validate-tasks` and `print-tasks` will try to use the `DefaultOrganizationAccessRoleName` instead of the expected `DefaultBuildAccessRoleName` or `DefaultDevelopmentBuildAccessRoleName`.

In particular, for a task:

```yml
MyTask:
  Type: update-stacks
  Skip: false
  Template: s3://my-s3-bucket/hello-world.yml
  ...
```

We get the following error:

```yml
ERROR: Task MyTask validated failed. reason: unable to load file s3://my-s3-bucket/hello-world.yml. 
reason: unable to get contents of S3 hosted file (path: s3://my-s3-bucket/hello-world.yml), error: User: arn:aws:sts::111111111111:assumed-role/my-cicd-deploy-role/my-role is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::111111111111:role/OurDefaultORganizationAccessRole.
```

Where `OurDefaultORganizationAccessRole` is the role name specified for `DefaultOrganizationAccessRoleName` on the `OrganizationRoot`.

# Solution

In order to use the seemingly correct roles, we basically just have to initialize the GlobalState in these commands with the same logic as it is done in `perform-tasks`.

